### PR TITLE
Fixes for notebook link and model description

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Because I am a dog lover (sorry cat friends, but you can easily train your own c
 
 I used the [Stanford Dogs Dataset](http://vision.stanford.edu/aditya86/ImageNetDogs/), which contains 137 different breeds of dogs with about 150 images per breed.
 
-The training process is described in detail in [this jupyter notebook](train_dog_classifier_with_fastai_to_ONNX.ipynb) (coming soon). Note: You can [run this notebook for free in Google Colabatory](https://colab.research.google.com/github/davidpfahler/react-ml-app/blob/master/train_dog_classifier_with_fastai_to_ONNX.ipynb) if you have a Google account.
+The training process is described in detail in [this jupyter notebook](train_dog_classifier_with_fastai_export_to_ONNX.ipynb). Note: You can [run this notebook for free in Google Colabatory](https://colab.research.google.com/github/davidpfahler/react-ml-app/blob/master/train_dog_classifier_with_fastai_export_to_ONNX.ipynb) if you have a Google account.
 
 I am using a resnet34 architecture, but I am planning to investigate more efficient architectures in the future and will update this project accordingly if I find them to be useful.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ I used the [Stanford Dogs Dataset](http://vision.stanford.edu/aditya86/ImageNetD
 
 The training process is described in detail in [this jupyter notebook](train_dog_classifier_with_fastai_export_to_ONNX.ipynb). Note: You can [run this notebook for free in Google Colabatory](https://colab.research.google.com/github/davidpfahler/react-ml-app/blob/master/train_dog_classifier_with_fastai_export_to_ONNX.ipynb) if you have a Google account.
 
-I am using a resnet34 architecture, but I am planning to investigate more efficient architectures in the future and will update this project accordingly if I find them to be useful.
+I am using a resnet18 architecture, but I am planning to investigate more efficient architectures in the future and will update this project accordingly if I find them to be useful.
 
 ## The Frontend
 


### PR DESCRIPTION
I was reading your post on how to take a fastai model and create a web page running it. Thanks for writing that. I noticed a couple of things while reading.

The notebook links were broken (missing the word export) and the text stated resnet34 while the code referenced resnet18.

I didn't change the licensing paragraph, so I'm guessing the editor in the GitHub web page may have changed the line ending.
